### PR TITLE
DS-4122 - Add asset-packagist.com for 3rd party libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,10 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
     }
   ],
   "scripts": {
@@ -46,6 +50,10 @@
     ]
   },
   "extra": {
+    "installer-types": [
+      "bower-asset",
+      "npm-asset"
+    ],
     "installer-paths": {
       "html/core": [
         "drupal/core"
@@ -61,6 +69,11 @@
       ],
       "html/themes/contrib/{$name}": [
         "type:drupal-theme"
+      ],
+      "html/libraries/{$name}": [
+        "type:drupal-library",
+        "type:bower-asset",
+        "type:npm-asset"
       ],
       "scripts/{$name}": [
           "goalgorilla/open_social_scripts"


### PR DESCRIPTION
## Description

We moved the front-end libraries to the composer.json file as dependencies. This requires an update for the composer.json file.

See also https://github.com/goalgorilla/social_template/pull/9.

## How to test

- [ ] Simply run `composer update` and `composer install`, both should still work fine