### PR TITLE
Add GMP library for Social PWA development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER devel@goalgorilla.com
 RUN apt-get update && apt-get install -y \
   php-pclzip \
   zlib1g-dev \
+  libgmp-dev \
   mysql-client \
   git \
   ssmtp \
@@ -19,7 +20,11 @@ RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail
 
 ADD php.ini /usr/local/etc/php/php.ini
 
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
+
 # Install extensions
+RUN docker-php-ext-configure gmp
+RUN docker-php-ext-install gmp
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install exif

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER devel@goalgorilla.com
 RUN apt-get update && apt-get install -y \
   php-pclzip \
   zlib1g-dev \
-  libgmp-dev \
   mysql-client \
   git \
   ssmtp \
@@ -20,11 +19,7 @@ RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail
 
 ADD php.ini /usr/local/etc/php/php.ini
 
-RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
-
 # Install extensions
-RUN docker-php-ext-configure gmp
-RUN docker-php-ext-install gmp
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install bcmath
 RUN docker-php-ext-install exif

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "phpmd/phpmd": "@stable",
     "pdepend/pdepend": "2.1.0",
     "sebastian/phpcpd": "*",
-    "phpunit/phpunit": "4.8"
+    "phpunit/phpunit": "^4.8"
   },
   "repositories": [
     {

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -18,6 +18,12 @@ RUN ln -s /var/www/vendor/bin/drupal /usr/local/bin/drupal
 
 ADD php.ini /usr/local/etc/php/php.ini
 
+# GMP library.
+RUN apt-get install -y libgmp-dev
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
+RUN docker-php-ext-configure gmp
+RUN docker-php-ext-install gmp
+
 # Xdebug.
 RUN pecl install xdebug
 RUN docker-php-ext-enable xdebug


### PR DESCRIPTION
## Problem
For the Social PWA module the GMP library is required. It is however not part of our Dockerfile.

## Solution
Added the steps and instructions as per https://bitbucket.org/goalgorilla/social_pwa/wiki/How%20to%20enable%20gmp%20in%20your%20docker%20environment.

## HTT

- [ ] Rebuild your Docker container with these changes.
- [ ] Install the Social PWA module
- [ ] Notice the installation is fine and the status reports page shows no error regarding the GMP requirement