### PR TITLE
Revert back to PHP 7.1

### DIFF
--- a/1.0/Dockerfile
+++ b/1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:8
+FROM drupal:8.4
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:8
+FROM drupal:8.4
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.


### PR DESCRIPTION
## Problem
We're apparently using PHP 7.2 now, but because we're on Drupal 8.4.x the tests are all failing due to incompatibilities.

E.g. https://www.drupal.org/project/drupal/issues/2923015

## Solution
Go back to PHP 7.1 until we updated Drupal Core.