### PR TITLE
Disable max_execution_time for local development

### DIFF
--- a/dev/php.ini
+++ b/dev/php.ini
@@ -9,6 +9,7 @@ file_uploads = On
 ; CI settings - see ../ci/php.ini
 ; TODO Change memory_limit to prod value.
 memory_limit = 1024M
+max_execution_time = 0
 
 ; Dev settings
 xdebug.max_nesting_level = 500


### PR DESCRIPTION
When performing local development an initial uncached page load can take quite some time longer than PHP's default 30 second time limit.

This disables the max_execution_time for local development.