### PR TITLE
Updated libraries and replaced older dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM drupal:8.9
+FROM drupal:8.7
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.
 RUN apt-get update && apt-get install -y \
   zlib1g-dev \
-  mysql-client \
+  mariadb-client \
   git \
-  ssmtp \
+  msmtp \
+  libzip-dev \
   nano \
   vim && \
   apt-get clean
 
-ADD mailcatcher-ssmtp.conf /etc/ssmtp/ssmtp.conf
+ADD mailcatcher-msmtp.conf /etc/msmtprc
 
-RUN echo 'sendmail_path = "/usr/sbin/ssmtp -t"' > /usr/local/etc/php/conf.d/mail.ini
+RUN echo 'sendmail_path = "/usr/bin/msmtp -t"' > /usr/local/etc/php/conf.d/mail.ini
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:8.7
+FROM drupal:8.9
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN docker-php-ext-install zip bcmath exif
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
+RUN composer self-update --1
 
 # Install Open Social via composer.
 RUN rm -f /var/www/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,14 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer/installers": "^1.0",
-        "drupal-composer/drupal-scaffold": "^2.0.0",
-        "cweagans/composer-patches": "^1.0",
         "drush/drush": "8.*@stable",
-        "goalgorilla/open_social": "dev-8.x-4.x",
+        "goalgorilla/open_social": "dev-8.x-9.x",
         "goalgorilla/open_social_scripts": "dev-master"
     },
     "require-dev": {
         "jcalderonzumba/gastonjs": "~1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
-        "mikey179/vfsStream": "~1.2",
+        "mikey179/vfsstream": "~1.2",
         "symfony/css-selector": "~2.8",
         "behat/behat": "3.*@stable",
         "behat/mink": "1.*@stable",

--- a/mailcatcher-msmtp.conf
+++ b/mailcatcher-msmtp.conf
@@ -1,0 +1,5 @@
+account mailcatcher
+host mailcatcher
+port 1025
+auto_from on
+account default: mailcatcher


### PR DESCRIPTION
## Problem
When trying to push the latest build of Open Social docker we faced issues with outdated libraries.

![image](https://user-images.githubusercontent.com/8435994/99567270-44405280-29ce-11eb-8775-fd32a5eb46e0.png)

![image](https://user-images.githubusercontent.com/8435994/99567278-460a1600-29ce-11eb-89f7-dea3fa336213.png)

## Solution
Update libraries.

https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u
https://stackoverflow.com/questions/57194287/debian-package-ssmtp-has-no-installation-candidate

## HTT
1. Clone this branch.
2. Run `docker build --tag "goalgorilla/open_social_docker:latest" .`