### PR TITLE
Add sockets extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN echo 'sendmail_path = "/usr/bin/msmtp -t"' > /usr/local/etc/php/conf.d/mail.
 ADD php.ini /usr/local/etc/php/php.ini
 
 # Install extensions
-RUN docker-php-ext-install zip bcmath exif
+RUN docker-php-ext-install zip bcmath exif sockets
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
The sockets extension is used by the current version of 
drupal/rabbitmq 3.x which is required by the social_real_time
module on which the social_chat extension is built.

Enabling the extension this way should be enough to make the CI
for the mentioned modules work again. There is a known issue in
some specific PHP docker image versions but that seems to have
been fixed, see https://github.com/docker-library/php/issues/1245