### PR TITLE
Added libssl-dev package to be installed in Docker & also updated Drupal image version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM drupal:8.9
+FROM drupal:8.9.20
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.
 RUN apt-get update && apt-get install -y \
   zlib1g-dev \
+  libssl-dev \
   mariadb-client \
   git \
   msmtp \


### PR DESCRIPTION
Docker builds on the Apple M1 chip-based machines were failing due to Segmentation fault errors. On investigation, it was found that it is a known issue and has been listed in https://docs.docker.com/desktop/mac/troubleshoot/#known-issues. We currently have no control over which version of Ubuntu gets installed as we are based on Drupal docker image, so I have added libssl-dev package to DockerFile.

See: https://drupal.slack.com/archives/C4N6HELQL/p1648017690186089

HTT:

1. On an M1 chip-based Apple machine, checkout to master and run  `docker build --tag "goalgorilla/open_social_docker:latest" .`
2. You will get failure as shown below:

![Screenshot 2022-03-23 at 12 01 10 PM](https://user-images.githubusercontent.com/8435994/159683452-079ef503-8149-406b-b80b-8117414e9853.png)

3. Check out to this branch and run the same command. The build should be succesful.