### PR TITLE
Update docker image to use drupal 9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drupal:9.3.16-php8.0
+FROM drupal:9.4-php8.0
 MAINTAINER devel@goalgorilla.com
 
 # Install packages.


### PR DESCRIPTION
Update our current drupal 9.3 docker image to the latest drpal 9.4 php 8