### PR TITLE
Added soap php extensions required by cablecar and removed obselete libraries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER devel@goalgorilla.com
 RUN apt-get update && apt-get install -y \
   zlib1g-dev \
   libssl-dev \
+  libxml2-dev \
   mariadb-client \
   curl \
   wget \
@@ -24,7 +25,7 @@ RUN echo 'sendmail_path = "/usr/bin/msmtp -t"' > /usr/local/etc/php/conf.d/mail.
 ADD php.ini /usr/local/etc/php/php.ini
 
 # Install extensions
-RUN docker-php-ext-install zip bcmath exif sockets
+RUN docker-php-ext-install zip bcmath exif sockets soap
 
 # Install Composer.
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,9 @@
   "require": {
     "blackfire/php-sdk": "^v1.27.1",
     "drupal/redis": "^1.5",
-    "goalgorilla/open_social": "dev-main",
-    "goalgorilla/open_social_scripts": "^3.1"
+    "goalgorilla/open_social": "dev-main"
   },
   "require-dev": {
-    "drupal/composer_deploy": "^1.6",
-    "drupal/upgrade_status": "^3.11",
     "goalgorilla/open_social_dev": "dev-main",
     "palantirnet/drupal-rector": "^0.12",
     "phpmd/phpmd": "^2.10",


### PR DESCRIPTION
## Problem

Cablecar requires ext-soap extension.

![Screenshot 2022-11-17 at 8 59 29 AM](https://user-images.githubusercontent.com/8435994/202348043-20ee91c5-941c-4a46-9de6-dae112431a69.png)


## Solution
Add libxml2-dev library to be installed
Add soap php extension
Remove obsolete libraries from composer.json