### PR TITLE
Enable zend assertions in development

### DIFF
--- a/ci/php.ini
+++ b/ci/php.ini
@@ -9,3 +9,4 @@ file_uploads = On
 ; CI settings
 ; TODO Change memory_limit to prod value.
 memory_limit = 1024M
+zend.assertions = 1

--- a/dev/php.ini
+++ b/dev/php.ini
@@ -10,6 +10,7 @@ file_uploads = On
 ; TODO Change memory_limit to prod value.
 memory_limit = 1024M
 max_execution_time = 0
+zend.assertions = 1
 
 ; Dev settings
 xdebug.max_nesting_level = 500


### PR DESCRIPTION
We use `assert` in places to satisfy PHPStan when we know things should be a certain way.  Similarly we use it in tests when we know things should be a certain way (or to actually make test assertions).

However, until now `assert` wasn't actually executed in our local environments or in our test runners which can cause tests to fail unpredictably elsewhere.

This adds `zend.assertions = 1` to enable in development mode. We add a duplicate line so  that the top of the `php.ini` is still the same as the production one and it's clear that it's a  dev-only override.