### PR TITLE
Update Dockerfile to add `ext-intl`

### DIFF
--- a/ci-php8.1/Dockerfile
+++ b/ci-php8.1/Dockerfile
@@ -69,6 +69,11 @@ RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
 RUN docker-php-ext-configure gmp
 RUN docker-php-ext-install gmp
 
+# simplesamlphp/simplesamlphp 2.1.0 requires ext-intl.
+RUN apt-get install -y libicu-dev g++
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl
+
 # Install composer dependencies.
 RUN composer install --prefer-dist --no-interaction
 

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -81,6 +81,11 @@ RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/
 RUN docker-php-ext-configure gmp
 RUN docker-php-ext-install gmp
 
+# simplesamlphp/simplesamlphp 2.1.0 requires ext-intl.
+RUN apt-get install -y libicu-dev g++
+RUN docker-php-ext-configure intl
+RUN docker-php-ext-install intl
+
 # Xdebug.
 RUN pecl install xdebug-3.1.1 && \
     docker-php-ext-enable xdebug && \


### PR DESCRIPTION
`simplesamlphp/simplesamlphp:2.1.0` requires `ext-intl` so we have to add it here in order for developers to be able to use it when working with CableCar when all the D10 work lands.