### PR TITLE
Add PCOV to the Dockerfile

### DIFF
--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -87,13 +87,13 @@ RUN docker-php-ext-configure intl
 RUN docker-php-ext-install intl
 
 # Xdebug.
-RUN pecl install xdebug-3.1.1 && \
-    docker-php-ext-enable xdebug && \
-    sed -i '1 a xdebug.client_port=9003' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    sed -i '1 a xdebug.mode=debug' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    sed -i '1 a xdebug.discover_client_host=true' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    sed -i '1 a xdebug.client_host=host.docker.internal' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
-    sed -i '1 a xdebug.idekey=PHPSTORMi' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+#RUN pecl install xdebug-3.1.1 && \
+#    docker-php-ext-enable xdebug && \
+#    sed -i '1 a xdebug.client_port=9003' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+#    sed -i '1 a xdebug.mode=debug' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+#    sed -i '1 a xdebug.discover_client_host=true' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+#    sed -i '1 a xdebug.client_host=host.docker.internal' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+#    sed -i '1 a xdebug.idekey=PHPSTORMi' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 # PCOV
 RUN pecl install pcov && \

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -95,6 +95,10 @@ RUN pecl install xdebug-3.1.1 && \
     sed -i '1 a xdebug.client_host=host.docker.internal' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
     sed -i '1 a xdebug.idekey=PHPSTORMi' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
+# PCOV
+RUN pecl install pcov && \
+    docker-php-ext-enable pcov
+
 # Blackfire
 # @todo Fix PHP 8 based blackfire installation
 #RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \

--- a/php8.1/php.ini
+++ b/php8.1/php.ini
@@ -17,4 +17,4 @@ xdebug.max_nesting_level = 500
 opcache.enable = 0
 
 ; PCOV settings
-pcov.enabled = 0
+pcov.enabled = 1

--- a/php8.1/php.ini
+++ b/php8.1/php.ini
@@ -15,3 +15,6 @@ zend.assertions = 1
 ; Dev settings
 xdebug.max_nesting_level = 500
 opcache.enable = 0
+
+; PCOV settings
+pcov.enabled = 0


### PR DESCRIPTION
PCOV is useful for code coverage reports and much faster than XDebug (https://www.kurmis.com/2020/01/15/pcov-for-faster-code-coverage.html).

PCOV and XDebug are mutually exclusive. And with XDebug being used more, we keep PCOV disabled by default for now.