### PR TITLE
Fix drush path to allow using docker exec

### DIFF
--- a/drupal10/ci-php8.1/Dockerfile
+++ b/drupal10/ci-php8.1/Dockerfile
@@ -77,7 +77,7 @@ RUN ln -s /root/.composer/vendor/bin/behat /usr/local/bin/behat
 RUN ln -s /root/.composer/vendor/bin/phpunit /usr/local/bin/phpunit
 
 # Drush 12 removes the need for the launcher and uses composer from vendor binary.
-ENV PATH "$PATH:./vendor/bin:/usr/local/bin"
+ENV PATH "$PATH:/var/www/vendor/bin:/usr/local/bin"
 
 ### CI SPECIFIC - END ###
 

--- a/drupal10/php8.1/Dockerfile
+++ b/drupal10/php8.1/Dockerfile
@@ -65,7 +65,7 @@ RUN ln -s /root/.composer/vendor/bin/behat /usr/local/bin/behat
 RUN ln -s /root/.composer/vendor/bin/phpunit /usr/local/bin/phpunit
 
 # Drush 12 removes the need for the launcher and uses composer from vendor binary.
-ENV PATH "$PATH:./vendor/bin:/usr/local/bin"
+ENV PATH "$PATH:/var/www/vendor/bin:/usr/local/bin"
 
 ### CI SPECIFIC - END ###
 


### PR DESCRIPTION
The relative path requires a terminal session to be bootstrapped and very strictly requires running composer installed commands (such as drush) from the `/var/www` directory.

If trying to run drush using docker exec you'll run into
```
OCI runtime exec failed: exec failed: unable to start container
process: exec: "drush": cannot run executable found relative to
current directory: unknown
```

Instead we know where composer installed executables will live which is in `/var/www/vendor/bin`. By adding that as absolute path to our $PATH we ensure that drush can be used through docker exec again.