### PR TITLE
Create separate images `php8.1-v2` and `ci-php8.1-v2` with new extension `rdkafka`

### DIFF
--- a/drupal10/ci-php8.1-v2/Dockerfile
+++ b/drupal10/ci-php8.1-v2/Dockerfile
@@ -1,0 +1,77 @@
+FROM drupal:10.0.11-php8.1
+MAINTAINER devel@goalgorilla.com
+
+# Install packages.
+RUN apt-get update && apt-get install -y \
+  zlib1g-dev \
+  libssl-dev \
+  libxml2-dev \
+  mariadb-client \
+  curl \
+  wget \
+  git \
+  msmtp \
+  libzip-dev \
+  nano \
+  p7zip-full \
+  vim && \
+  apt-get clean
+
+
+ADD mailcatcher-msmtp.conf /etc/msmtprc
+
+RUN echo 'sendmail_path = "/usr/bin/msmtp -t"' > /usr/local/etc/php/conf.d/mail.ini
+
+ADD php.ini /usr/local/etc/php/php.ini
+
+# Install extensions
+RUN curl -sSLf \
+        -o /usr/local/bin/install-php-extensions \
+        https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
+    chmod +x /usr/local/bin/install-php-extensions
+RUN install-php-extensions zip bcmath exif sockets soap gmp intl rdkafka
+
+# Install Composer.
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+    php composer-setup.php \
+    php -r "unlink('composer-setup.php');"
+
+
+# Install Open Social via composer.
+RUN rm -f /var/www/composer.lock
+RUN rm -rf /root/.composer
+
+ADD composer.json /var/www/composer.json
+WORKDIR /var/www/
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-dev
+
+WORKDIR /var/www/html/
+RUN chown -R www-data:www-data *
+
+RUN php -r 'opcache_reset();'
+
+# Fix shell.
+RUN echo "export TERM=xterm" >> ~/.bashrc
+
+# Specify the work directory.
+WORKDIR /var/www/
+
+ADD php.ini /usr/local/etc/php/php.ini
+
+### CI SPECIFIC - START ###
+
+# Install composer dependencies.
+RUN composer install --prefer-dist --no-interaction
+
+# Unfortunately, adding the composer vendor dir to the PATH doesn't seem to work. So:
+RUN ln -s /root/.composer/vendor/bin/behat /usr/local/bin/behat
+RUN ln -s /root/.composer/vendor/bin/phpunit /usr/local/bin/phpunit
+
+# Drush 12 removes the need for the launcher and uses composer from vendor binary.
+ENV PATH "$PATH:/var/www/vendor/bin:/usr/local/bin"
+
+### CI SPECIFIC - END ###
+
+RUN php -r "opcache_reset();"

--- a/drupal10/ci-php8.1-v2/composer.json
+++ b/drupal10/ci-php8.1-v2/composer.json
@@ -1,0 +1,106 @@
+{
+  "name": "goalgorilla/social_docker",
+  "description": "Social docker template for composer based Open Social projects.",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "optimize-autoloader": true,
+    "update-with-dependencies": true,
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "cweagans/composer-patches": true,
+      "drupal/core-composer-scaffold": true,
+      "oomphinc/composer-installers-extender": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true,
+      "drupal/console-extend-plugin": true,
+      "zaporylie/composer-drupal-optimizations": true
+    }
+  },
+  "require": {
+    "blackfire/php-sdk": "^v1.27.1",
+    "drupal/redis": "^1.6",
+    "goalgorilla/open_social": "dev-main"
+  },
+  "require-dev": {
+    "goalgorilla/open_social_dev": "dev-main",
+    "palantirnet/drupal-rector": "^0.12",
+    "phpmd/phpmd": "^2.10",
+    "squizlabs/html_codesniffer": "*",
+    "symplify/easy-coding-standard": "^9.4"
+  },
+  "repositories": {
+    "0": {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8",
+      "exclude": ["goalgorilla/open_social", "drupal/social"]
+    },
+    "1": {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    },
+    "2": {
+      "type": "package",
+      "package": {
+        "name": "squizlabs/html_codesniffer",
+        "version": "2.5.1",
+        "source": {
+          "url": "https://github.com/squizlabs/HTML_CodeSniffer.git",
+          "type": "git",
+          "reference": "master"
+        }
+      }
+    },
+    "3": {
+      "type": "git",
+      "url": "https://github.com/goalgorilla/open_social.git",
+      "only": ["goalgorilla/open_social", "drupal/social"]
+    }
+  },
+  "extra": {
+    "installer-types": [
+      "bower-asset",
+      "npm-asset"
+    ],
+    "installer-paths": {
+      "html/core": [
+        "drupal/core"
+      ],
+      "html/modules/contrib/{$name}": [
+        "type:drupal-module"
+      ],
+      "html/profiles/contrib/social": [
+        "goalgorilla/open_social"
+      ],
+      "html/profiles/contrib/{$name}": [
+        "type:drupal-profile"
+      ],
+      "html/themes/contrib/{$name}": [
+        "type:drupal-theme"
+      ],
+      "html/libraries/{$name}": [
+        "type:drupal-library",
+        "type:bower-asset",
+        "type:npm-asset"
+      ],
+      "scripts/{$name}": [
+        "goalgorilla/open_social_scripts"
+      ],
+      "drush/contrib/{$name}": [
+        "type:drupal-drush"
+      ]
+    },
+    "enable-patching": true,
+    "patchLevel": {
+      "drupal/core": "-p2"
+    },
+    "drupal-scaffold": {
+      "locations": {
+        "web-root": "html/"
+      }
+    }
+  }
+}

--- a/drupal10/ci-php8.1-v2/mailcatcher-msmtp.conf
+++ b/drupal10/ci-php8.1-v2/mailcatcher-msmtp.conf
@@ -1,0 +1,5 @@
+account mailcatcher
+host mailcatcher
+port 1025
+auto_from on
+account default: mailcatcher

--- a/drupal10/ci-php8.1-v2/php.ini
+++ b/drupal10/ci-php8.1-v2/php.ini
@@ -1,0 +1,12 @@
+[PHP]
+; Prod settings -- see ../prod/php.ini
+date.timezone = UTC
+zend.assertions	= 0
+upload_max_filesize = 24M
+post_max_size = 32M
+file_uploads = On
+
+; CI settings
+; TODO Change memory_limit to prod value.
+memory_limit = 1024M
+zend.assertions = 1

--- a/drupal10/php8.1-v2/Dockerfile
+++ b/drupal10/php8.1-v2/Dockerfile
@@ -1,0 +1,109 @@
+FROM drupal:10.0.11-php8.1
+MAINTAINER devel@goalgorilla.com
+
+# Install packages.
+RUN apt-get update && apt-get install -y \
+  zlib1g-dev \
+  libssl-dev \
+  libxml2-dev \
+  mariadb-client \
+  curl \
+  wget \
+  git \
+  msmtp \
+  libzip-dev \
+  nano \
+  p7zip-full \
+  vim && \
+  apt-get clean
+
+
+ADD mailcatcher-msmtp.conf /etc/msmtprc
+
+RUN echo 'sendmail_path = "/usr/bin/msmtp -t"' > /usr/local/etc/php/conf.d/mail.ini
+
+ADD php.ini /usr/local/etc/php/php.ini
+
+# Install extensions
+RUN curl -sSLf \
+        -o /usr/local/bin/install-php-extensions \
+        https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions && \
+    chmod +x /usr/local/bin/install-php-extensions
+RUN install-php-extensions zip bcmath exif sockets soap gmp intl redis rdkafka
+
+# Install Composer.
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    php -r "if (hash_file('sha384', 'composer-setup.php') === 'e21205b207c3ff031906575712edab6f13eb0b361f2085f1f1237b7126d785e826a450292b6cfd1d64d92e6563bbde02') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+    php composer-setup.php \
+    php -r "unlink('composer-setup.php');"
+
+
+# Install Open Social via composer.
+RUN rm -f /var/www/composer.lock
+RUN rm -rf /root/.composer
+
+ADD composer.json /var/www/composer.json
+WORKDIR /var/www/
+ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN COMPOSER_MEMORY_LIMIT=-1 composer install --prefer-dist --no-interaction --no-dev
+
+WORKDIR /var/www/html/
+RUN chown -R www-data:www-data *
+
+RUN php -r 'opcache_reset();'
+
+# Fix shell.
+RUN echo "export TERM=xterm" >> ~/.bashrc
+
+### CI SPECIFIC - START ###
+### - Making changes here? Also apply in ../ci/Dockerfile ###
+
+# Specify the work directory.
+WORKDIR /var/www/
+
+# Install composer dependencies.
+RUN composer install --prefer-dist --no-interaction
+
+# Unfortunately, adding the composer vendor dir to the PATH doesn't seem to work. So:
+RUN ln -s /root/.composer/vendor/bin/behat /usr/local/bin/behat
+RUN ln -s /root/.composer/vendor/bin/phpunit /usr/local/bin/phpunit
+
+# Drush 12 removes the need for the launcher and uses composer from vendor binary.
+ENV PATH "$PATH:/var/www/vendor/bin:/usr/local/bin"
+
+### CI SPECIFIC - END ###
+
+### DEV SPECIFIC - START ###
+
+ADD php.ini /usr/local/etc/php/php.ini
+
+# Xdebug.
+RUN pecl install xdebug-3.1.1 && \
+    docker-php-ext-enable xdebug && \
+    sed -i '1 a xdebug.client_port=9003' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    sed -i '1 a xdebug.mode=debug' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    sed -i '1 a xdebug.discover_client_host=true' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    sed -i '1 a xdebug.client_host=host.docker.internal' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && \
+    sed -i '1 a xdebug.idekey=PHPSTORMi' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+# Blackfire
+# @todo Fix PHP 8 based blackfire installation
+#RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+#    && architecture=$(uname -m) \
+#    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/$architecture/$version \
+#    && mkdir -p /tmp/blackfire \
+#    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+#    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so \
+#    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8307\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
+#    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
+RUN php -r "opcache_reset();"
+
+# @todo Remove these steps as it is not required for latest Docker desktop.
+# Contains the Mac hack to get the permissions to work for development.
+# Set user 1000 and group staff to www-data, enables write permission.
+# https://github.com/boot2docker/boot2docker/issues/581#issuecomment-114804894
+#RUN usermod -u 1000 www-data
+#RUN usermod -G staff www-data
+
+### DEV SPECIFIC - END ###

--- a/drupal10/php8.1-v2/composer.json
+++ b/drupal10/php8.1-v2/composer.json
@@ -1,0 +1,106 @@
+{
+  "name": "goalgorilla/social_docker",
+  "description": "Social docker template for composer based Open Social projects.",
+  "type": "project",
+  "license": "GPL-2.0-or-later",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "optimize-autoloader": true,
+    "update-with-dependencies": true,
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "cweagans/composer-patches": true,
+      "drupal/core-composer-scaffold": true,
+      "oomphinc/composer-installers-extender": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true,
+      "drupal/console-extend-plugin": true,
+      "zaporylie/composer-drupal-optimizations": true
+    }
+  },
+  "require": {
+    "blackfire/php-sdk": "^v1.27.1",
+    "drupal/redis": "^1.6",
+    "goalgorilla/open_social": "dev-main"
+  },
+  "require-dev": {
+    "goalgorilla/open_social_dev": "dev-main",
+    "palantirnet/drupal-rector": "^0.12",
+    "phpmd/phpmd": "^2.10",
+    "squizlabs/html_codesniffer": "*",
+    "symplify/easy-coding-standard": "^9.4"
+  },
+  "repositories": {
+    "0": {
+      "type": "composer",
+      "url": "https://packages.drupal.org/8",
+      "exclude": ["goalgorilla/open_social", "drupal/social"]
+    },
+    "1": {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
+    },
+    "2": {
+      "type": "package",
+      "package": {
+        "name": "squizlabs/html_codesniffer",
+        "version": "2.5.1",
+        "source": {
+          "url": "https://github.com/squizlabs/HTML_CodeSniffer.git",
+          "type": "git",
+          "reference": "master"
+        }
+      }
+    },
+    "3": {
+      "type": "git",
+      "url": "https://github.com/goalgorilla/open_social.git",
+      "only": ["goalgorilla/open_social", "drupal/social"]
+    }
+  },
+  "extra": {
+    "installer-types": [
+      "bower-asset",
+      "npm-asset"
+    ],
+    "installer-paths": {
+      "html/core": [
+        "drupal/core"
+      ],
+      "html/modules/contrib/{$name}": [
+        "type:drupal-module"
+      ],
+      "html/profiles/contrib/social": [
+        "goalgorilla/open_social"
+      ],
+      "html/profiles/contrib/{$name}": [
+        "type:drupal-profile"
+      ],
+      "html/themes/contrib/{$name}": [
+        "type:drupal-theme"
+      ],
+      "html/libraries/{$name}": [
+        "type:drupal-library",
+        "type:bower-asset",
+        "type:npm-asset"
+      ],
+      "scripts/{$name}": [
+        "goalgorilla/open_social_scripts"
+      ],
+      "drush/contrib/{$name}": [
+        "type:drupal-drush"
+      ]
+    },
+    "enable-patching": true,
+    "patchLevel": {
+      "drupal/core": "-p2"
+    },
+    "drupal-scaffold": {
+      "locations": {
+        "web-root": "html/"
+      }
+    }
+  }
+}

--- a/drupal10/php8.1-v2/mailcatcher-msmtp.conf
+++ b/drupal10/php8.1-v2/mailcatcher-msmtp.conf
@@ -1,0 +1,5 @@
+account mailcatcher
+host mailcatcher
+port 1025
+auto_from on
+account default: mailcatcher

--- a/drupal10/php8.1-v2/php.ini
+++ b/drupal10/php8.1-v2/php.ini
@@ -1,0 +1,17 @@
+[PHP]
+; Prod settings -- see ../prod/php.ini
+date.timezone = UTC
+zend.assertions	= 0
+upload_max_filesize = 24M
+post_max_size = 32M
+file_uploads = On
+
+; CI settings - see ../ci/php.ini
+; TODO Change memory_limit to prod value.
+memory_limit = 1024M
+max_execution_time = 0
+zend.assertions = 1
+
+; Dev settings
+xdebug.max_nesting_level = 500
+opcache.enable = 0


### PR DESCRIPTION
This PR creates separate images `php8.1-v2` and `ci-php8.1-v2` with the new extension `rdkafka`.

Since the new extension is not available in `docker-php-ext-install`, we are using a different command provided by https://github.com/mlocati/docker-php-extension-installer. It also allows us to install `gmp`, `intl` and `redis` so we don't need the custom commands anymore.